### PR TITLE
Initial impl of escaped SOF

### DIFF
--- a/TF_Config.example.h
+++ b/TF_Config.example.h
@@ -17,10 +17,10 @@
 // If the connection is reliable, you can disable the SOF byte and checksums.
 // That can save up to 9 bytes of overhead.
 
-// ,-----+-----+-----+------+------------+- - - -+-------------,                
-// | SOF | ID  | LEN | TYPE | HEAD_CKSUM | DATA  | DATA_CKSUM  |                
+// ,-----+-----+-----+------+------------+- - - -+-------------,
+// | SOF | ID  | LEN | TYPE | HEAD_CKSUM | DATA  | DATA_CKSUM  |
 // | 0-1 | 1-4 | 1-4 | 1-4  | 0-4        | ...   | 0-4         | <- size (bytes)
-// '-----+-----+-----+------+------------+- - - -+-------------'                
+// '-----+-----+-----+------+------------+- - - -+-------------'
 
 // !!! BOTH PEERS MUST USE THE SAME SETTINGS !!!
 
@@ -39,6 +39,14 @@
 #define TF_USE_SOF_BYTE 1
 // Value of the SOF byte (if TF_USE_SOF_BYTE == 1)
 #define TF_SOF_BYTE     0x01
+
+// SOF *always* marks start of frame, if it appears elsewhere it will be escaped
+// a SOF byte appearing mid-message resets parsing and drops the unprocessed half.
+// When enabled, only 1 byte at a time is sent to TF_WriteImpl. This will incur
+// a performance penalty if you expect to send large chunks with DMA
+#define TF_ESCAPE_SOF_BYTE 1
+// if this byte is seen and TF_ESCAPE_SOF_BYTE == 1, the next byte is treated literally
+#define TF_ESCAPE_BYTE 0x02
 
 //----------------------- PLATFORM COMPATIBILITY ----------------------------
 

--- a/TinyFrame.h
+++ b/TinyFrame.h
@@ -81,6 +81,18 @@
 
 //endregion
 
+//region Sanity checks
+
+#if TF_ESCAPE_SOF_BYTE && !TF_USE_SOF_BYTE
+    #error TF_ESCAPE_SOF_BYTE enabled but TF_USE_SOF_BYTE disabled
+#endif
+
+#if TF_SOF_BYTE == TF_ESCAPE_BYTE
+    #error SOF byte is identical to escape byte
+#endif
+
+//endregion
+
 //---------------------------------------------------------------------------
 
 /** Peer bit enum (used for init) */
@@ -445,6 +457,10 @@ struct TinyFrame_ {
     TF_CKSUM ref_cksum;     //!< Reference checksum read from the message
     TF_TYPE type;           //!< Collected message type number
     bool discard_data;      //!< Set if (len > TF_MAX_PAYLOAD) to read the frame, but ignore the data.
+
+#if TF_ESCAPE_SOF_BYTE
+    bool escape_next;       //!< Track whether to escape the next character
+#endif
 
     /* Tx state */
     // Buffer for building frames


### PR DESCRIPTION
Related to #16 

I'm not entirely happy with this impl - while it's simple enough, it completely removes buffering on TF_WriteImpl. I could improve this to fill the buffer with escaped bytes, or split buffer writes on each escaped char, but it's a bit more code refactoring.

I've tested this internally and it works, and when disabled does not affect old code. Thoughts on the 1-byte-at-a-time aspect? Not sure if it's mergeable.

I also have an impl of this for PonyFrame, if you like. It's much simpler, at least.